### PR TITLE
Navigation Fix #70

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,13 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import { BrowserRouter, Route } from 'react-router-dom'
-
-const getBasename = path => path.substr(0, path.lastIndexOf('/'));
+import { HashRouter, Route } from 'react-router-dom'
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter basename={getBasename(window.location.pathname)}>
-        <Route path="/" component={App}/>
-    </BrowserRouter>
+    <HashRouter>
+      <Route path="/" component={App}/>
+    </HashRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
Fixed navigation error #70 

This was done by changing BrowserRouter to HashRouter. 

BrowserRouter is required to include the basename in the code. Since we do not know where the app will be deployed ahead of time the BrowserRouter solution won't work for us. 

BrowserRouter needs to know the basename for the reason that http requests must know to go to `/basename` first. A simple example is as follows:
You are at `dois/search`. If you refresh the page, an http request is sent to `dois/search`. There is nothing there because your app is located at `dois/` so you will get a 404 not found. The server would have to know to redirect `dois/search` to `dois/` so that your app can pick it up and do a client side transition to `dois/search`.

We can assume we don't have control over the server so BrowserRouter is not an acceptable solution. 

HashRouter uses a `#` to transition to different server side renderings. For example a request to `dois/#/search` will always go to `dois/` first then transition to `dois/#/search`. This is sufficient for our use as the browser back and forward buttons work, refreshes work and we are not worried about SEO for this app.

fixes #70 